### PR TITLE
Lumen support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 docs
 vendor
 coverage
+.phpunit.result.cache
+/.idea

--- a/src/CallWebhookJob.php
+++ b/src/CallWebhookJob.php
@@ -8,7 +8,6 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
@@ -18,7 +17,7 @@ use Spatie\WebhookServer\Events\WebhookCallSucceededEvent;
 
 class CallWebhookJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use InteractsWithQueue, Queueable, SerializesModels;
 
     public ?string $webhookUrl = null;
 

--- a/src/WebhookCall.php
+++ b/src/WebhookCall.php
@@ -178,13 +178,6 @@ class WebhookCall
         dispatch($this->callWebhookJob);
     }
 
-    public function dispatchNow(): void
-    {
-        $this->prepareForDispatch();
-
-        dispatch_now($this->callWebhookJob);
-    }
-
     protected function prepareForDispatch(): void
     {
         if (! $this->callWebhookJob->webhookUrl) {

--- a/tests/CallWebhookJobTest.php
+++ b/tests/CallWebhookJobTest.php
@@ -42,16 +42,6 @@ class CallWebhookJobTest extends TestCase
     }
 
     /** @test */
-    public function it_can_make_a_synchronous_webhook_call()
-    {
-        $this->baseWebhook()->dispatchNow();
-
-        $this
-            ->testClient
-            ->assertRequestsMade([$this->baseRequest()]);
-    }
-
-    /** @test */
     public function it_can_use_a_different_http_verb()
     {
         $this


### PR DESCRIPTION
Description
---
Removed dependencies & features to make the package work with Lumen nicely.

- [x] Removed the `Dispatchable` trait as it's not available in Lumen
- [x] Removed the `dispatchNow()` method from the `WebhookCall` class as it depends on the availability of the `Dispatchable` trait